### PR TITLE
Environment-Based URL Generation

### DIFF
--- a/env.template
+++ b/env.template
@@ -1,10 +1,11 @@
 # Server configurations
+DOMAIN=localhost
+SSL=false
+ENVIRONMENT=local
 SERVER_INTERNAL_PORT=8080
 SERVER_EXPOSED_PORT=8080
 SERVER_MAX_FILE_SIZE=10MB
 SERVER_MAX_REQUEST_SIZE=20MB
-DOMAIN=localhost
-SSL=false
 # Server docker configuration
 SERVER_IMAGE_NAME=gestifysolution-server
 SERVER_IMAGE_VERSION=1.0.0

--- a/src/main/java/com/ventuit/adminstrativeapp/shared/services/implementations/FilesServiceImpl.java
+++ b/src/main/java/com/ventuit/adminstrativeapp/shared/services/implementations/FilesServiceImpl.java
@@ -61,6 +61,9 @@ public class FilesServiceImpl implements FilesServiceInterface {
     @Value("${server.port}")
     private String serverPort;
 
+    @Value("${app.environment}")
+    private String environment;
+
     /**
      * Upload a file to storage and register it in the database
      * 
@@ -613,8 +616,16 @@ public class FilesServiceImpl implements FilesServiceInterface {
     private String generateFileUrl(String fileKey, String filePath) {
         // Determine if this is an image based on the file key extension
         String endpoint = isImageFile(fileKey) ? "images" : "files";
-        return String.format("%s://%s:%s/api/v1/minio/%s%s", ssl ? "https" : "http", domain, serverPort, endpoint,
-                filePath + "/" + fileKey);
+
+        // Construct the base URL
+        String baseUrl;
+        if ("local".equalsIgnoreCase(environment)) {
+            baseUrl = String.format("%s://%s:%s", ssl ? "https" : "http", domain, serverPort);
+        } else {
+            baseUrl = String.format("%s://%s", ssl ? "https" : "http", domain);
+        }
+
+        return String.format("%s/api/v1/minio/%s%s", baseUrl, endpoint, filePath + "/" + fileKey);
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,7 @@ app:
         admin-client: ${KEYCLOAK_ADMIN_CLIENT_NAME}
         client: ${KEYCLOAK_CLIENT_NAME}
     domain: ${DOMAIN}
+    environment: ${ENVIRONMENT}
     ssl: ${SSL}
     minio:
         endpoint: http://${MINIO_SERVICE_NAME}:${MINIO_INTERNAL_PORT_API}


### PR DESCRIPTION
Issue
The application needed to generate different file URLs depending on the environment:

Local: Include the port (e.g., http://domain:8080/...).
Other: Omit the port (e.g., https://domain/...).
Resolution
We introduced an ENVIRONMENT variable and updated the URL generation logic in 
FilesServiceImpl
.

Changes
.env & env.template: Added ENVIRONMENT=local.
application.yml: Mapped app.environment to ${ENVIRONMENT}.
FilesServiceImpl.java:
Injected app.environment value.
Updated 
generateFileUrl
 to check if environment is "local" and conditionally append the port.