### PR TITLE
feat: Seed Service Cleanup & Unique Business Products Endpoint

### DIFF
--- a/src/main/java/com/ventuit/adminstrativeapp/businesses/controllers/BusinessesController.java
+++ b/src/main/java/com/ventuit/adminstrativeapp/businesses/controllers/BusinessesController.java
@@ -14,6 +14,12 @@ import com.ventuit.adminstrativeapp.businesses.services.BusinessesService;
 import com.ventuit.adminstrativeapp.core.controllers.implementations.CrudControllerImpl;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import com.ventuit.adminstrativeapp.products.dto.ListProductDto;
+
 @RestController
 @RequestMapping("businesses")
 public class BusinessesController
@@ -37,6 +43,14 @@ public class BusinessesController
             @ModelAttribute UpdateBusinessesDto businessesDto) {
         ListBusinessesDto entityCreated = this.service.update(id, businessesDto);
         return ResponseEntity.ok(entityCreated);
+    }
+
+    @GetMapping("/{businessId}/products")
+    public ResponseEntity<Page<ListProductDto>> getProductsByBusinessId(
+            @PathVariable Integer businessId,
+            @RequestParam(required = false) Integer categoryId,
+            Pageable pageable) {
+        return ResponseEntity.ok(this.service.getProductsByBusinessId(businessId, categoryId, pageable));
     }
 
 }

--- a/src/main/java/com/ventuit/adminstrativeapp/businesses/services/BusinessesService.java
+++ b/src/main/java/com/ventuit/adminstrativeapp/businesses/services/BusinessesService.java
@@ -25,6 +25,12 @@ import com.ventuit.adminstrativeapp.storage.minio.MinioProvider;
 import jakarta.transaction.Transactional;
 import jakarta.transaction.Transactional.TxType;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import com.ventuit.adminstrativeapp.products.repositories.ProductsRepository;
+import com.ventuit.adminstrativeapp.products.mappers.ProductsMapper;
+import com.ventuit.adminstrativeapp.products.dto.ListProductDto;
+
 @Service
 public class BusinessesService
         extends
@@ -34,9 +40,19 @@ public class BusinessesService
     private FilesServiceImpl filesService;
     @Autowired
     private MinioProvider minioProvider;
+    @Autowired
+    private ProductsRepository productsRepository;
+    @Autowired
+    private ProductsMapper productsMapper;
 
     public BusinessesService(BusinessesRepository repository, BusinessesMapper mapper) {
         super(repository, mapper);
+    }
+
+    @Transactional(value = TxType.SUPPORTS)
+    public Page<ListProductDto> getProductsByBusinessId(Integer businessId, Integer categoryId, Pageable pageable) {
+        return productsRepository.findDistinctProductsByBusinessId(businessId, categoryId, pageable)
+                .map(productsMapper::toShowDto);
     }
 
     @Override

--- a/src/main/java/com/ventuit/adminstrativeapp/core/database/seeders/businesses/IndustriesSeeder.java
+++ b/src/main/java/com/ventuit/adminstrativeapp/core/database/seeders/businesses/IndustriesSeeder.java
@@ -69,7 +69,9 @@ public class IndustriesSeeder implements CommandLineRunner {
         @Override
         public void run(String... args) throws Exception {
                 try {
-                        insertIndustries();
+                        if (industriesRepository.count() == 0) {
+                                insertIndustries();
+                        }
                 } catch (Exception error) {
                         logger.error("An error has occurred when inserting data into the industries table", error);
                 }

--- a/src/main/java/com/ventuit/adminstrativeapp/core/database/seeders/businesses/TypesRegimensTaxesSeeder.java
+++ b/src/main/java/com/ventuit/adminstrativeapp/core/database/seeders/businesses/TypesRegimensTaxesSeeder.java
@@ -61,7 +61,9 @@ public class TypesRegimensTaxesSeeder implements CommandLineRunner {
         @Override
         public void run(String... args) throws Exception {
                 try {
-                        insertRegimensTaxes();
+                        if (typesRegimensTaxesRepository.count() == 0) {
+                                insertRegimensTaxes();
+                        }
                 } catch (Exception error) {
                         log.error("An error has occurred when inserting data into the tax_regimens table", error);
                 }

--- a/src/main/java/com/ventuit/adminstrativeapp/keycloak/services/implementations/KeycloakUsersServiceImpl.java
+++ b/src/main/java/com/ventuit/adminstrativeapp/keycloak/services/implementations/KeycloakUsersServiceImpl.java
@@ -185,4 +185,22 @@ public class KeycloakUsersServiceImpl implements KeycloakUsersServiceInterface {
         }
     }
 
+    @Override
+    public void deleteAllUsers() {
+        // Retrieve the UsersResource for the specified realm
+        UsersResource usersResource = keycloak.getAdminClient().users();
+
+        // Get all users
+        List<UserRepresentation> users = usersResource.list(0, 1000); // Pagination might be needed if user count > 1000
+
+        for (UserRepresentation user : users) {
+            try {
+                usersResource.delete(user.getId());
+            } catch (Exception e) {
+                // Log error but continue
+                e.printStackTrace();
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/ventuit/adminstrativeapp/keycloak/services/interfaces/KeycloakUsersServiceInterface.java
+++ b/src/main/java/com/ventuit/adminstrativeapp/keycloak/services/interfaces/KeycloakUsersServiceInterface.java
@@ -19,4 +19,6 @@ public interface KeycloakUsersServiceInterface {
     boolean disabledUserByUsername(String username);
 
     boolean deleteUserByUsername(String username);
+
+    void deleteAllUsers();
 }

--- a/src/main/java/com/ventuit/adminstrativeapp/products/repositories/ProductsRepository.java
+++ b/src/main/java/com/ventuit/adminstrativeapp/products/repositories/ProductsRepository.java
@@ -2,6 +2,10 @@ package com.ventuit.adminstrativeapp.products.repositories;
 
 import com.ventuit.adminstrativeapp.products.models.ProductsModel;
 import com.ventuit.adminstrativeapp.core.repositories.BaseRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -9,4 +13,17 @@ public interface ProductsRepository extends BaseRepository<ProductsModel, Intege
     boolean existsById(Integer id);
 
     boolean existsByIdAndDeletedAtIsNull(Integer id);
+
+    @Query("SELECT DISTINCT p FROM ProductsModel p " +
+            "JOIN p.branchesProducts bp " +
+            "JOIN bp.branch b " +
+            "JOIN b.business bu " +
+            "WHERE bu.id = :businessId " +
+            "AND (:categoryId IS NULL OR p.category.id = :categoryId) " +
+            "AND p.deletedAt IS NULL " +
+            "AND p.active = true")
+    Page<ProductsModel> findDistinctProductsByBusinessId(
+            @Param("businessId") Integer businessId,
+            @Param("categoryId") Integer categoryId,
+            Pageable pageable);
 }

--- a/src/main/java/com/ventuit/adminstrativeapp/shared/services/implementations/FilesServiceImpl.java
+++ b/src/main/java/com/ventuit/adminstrativeapp/shared/services/implementations/FilesServiceImpl.java
@@ -499,6 +499,17 @@ public class FilesServiceImpl implements FilesServiceInterface {
         }
     }
 
+    @Override
+    public void deleteAllFiles() {
+        // Delete all records from database tables
+        filesBucketsRepository.deleteAll();
+        filesPathsRepository.deleteAll();
+        filesRepository.deleteAll();
+
+        // Clear MinIO bucket
+        minioService.clearBucket();
+    }
+
     // Private helper methods
 
     private String generateFileKey(String originalFileName) {

--- a/src/main/java/com/ventuit/adminstrativeapp/shared/services/interfaces/FilesServiceInterface.java
+++ b/src/main/java/com/ventuit/adminstrativeapp/shared/services/interfaces/FilesServiceInterface.java
@@ -22,4 +22,6 @@ public interface FilesServiceInterface {
 
     public boolean deleteFileFromAllBuckets(Integer fileId);
 
+    public void deleteAllFiles();
+
 }

--- a/src/main/java/com/ventuit/adminstrativeapp/storage/minio/services/MinioService.java
+++ b/src/main/java/com/ventuit/adminstrativeapp/storage/minio/services/MinioService.java
@@ -2,6 +2,7 @@ package com.ventuit.adminstrativeapp.storage.minio.services;
 
 import io.minio.*;
 import io.minio.errors.*;
+import io.minio.messages.Item;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
@@ -186,6 +187,30 @@ public class MinioService {
         } catch (Exception e) {
             log.error("Error checking if file is image: {}", e.getMessage(), e);
             return false;
+        }
+    }
+
+    public void clearBucket() {
+        try {
+            Iterable<Result<Item>> results = minioClient.listObjects(
+                    ListObjectsArgs.builder()
+                            .bucket(minioProvider.getBucketName())
+                            .recursive(true)
+                            .build());
+
+            for (Result<Item> result : results) {
+                Item item = result.get();
+                minioClient.removeObject(
+                        RemoveObjectArgs.builder()
+                                .bucket(minioProvider.getBucketName())
+                                .object(item.objectName())
+                                .build());
+                log.info("Deleted object: {}", item.objectName());
+            }
+            log.info("Bucket cleared successfully");
+        } catch (Exception e) {
+            log.error("Error clearing bucket: {}", e.getMessage(), e);
+            throw new FileDeleteException("Failed to clear bucket", e);
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR implements a robust data cleanup mechanism for the seeding process to prevent data conflicts and adds a new endpoint to retrieve unique products for a specific business.

## Key Changes

### 1. Seeder Enhancements & Cleanup
- **Comprehensive Cleanup**: Implemented a [cleanup()](cci:1://file:///workspace/gestifysolution-server/src/main/java/com/ventuit/adminstrativeapp/shared/services/implementations/SeedServiceImpl.java:110:4-153:5) method in [SeedService](cci:2://file:///workspace/gestifysolution-server/src/main/java/com/ventuit/adminstrativeapp/shared/services/implementations/SeedServiceImpl.java:71:0-485:1) that runs before seeding to:
    - Delete all Keycloak users.
    - Truncate database tables in the correct reverse dependency order ([Branches](cci:2://file:///workspace/gestifysolution-server/src/main/java/com/ventuit/adminstrativeapp/branches/models/BranchesModel.java:29:0-77:1) -> [Products](cci:2://file:///workspace/gestifysolution-server/src/main/java/com/ventuit/adminstrativeapp/products/models/ProductsModel.java:24:0-57:1) -> [Categories](cci:1://file:///workspace/gestifysolution-server/src/main/java/com/ventuit/adminstrativeapp/shared/services/implementations/SeedServiceImpl.java:315:4-340:5) -> ...).
    - Clear the Minio storage bucket.
    - Delete file records *after* dependent entities to prevent Foreign Key violations.
- **Improved Seeder Logic**: Refactored [generateFakeProductCategories](cci:1://file:///workspace/gestifysolution-server/src/main/java/com/ventuit/adminstrativeapp/shared/services/implementations/SeedServiceImpl.java:315:4-340:5) and [generateFakeProducts](cci:1://file:///workspace/gestifysolution-server/src/main/java/com/ventuit/adminstrativeapp/shared/services/implementations/SeedServiceImpl.java:342:4-434:5) to capture and use valid, generated IDs instead of hardcoded ones. This resolves `ObjectNotValidException` errors and ensures data referential integrity.

### 2. Business Products Endpoint
- **New Endpoint**: `GET /api/v1/businesses/{businessId}/products`
- **Functionality**: Retrieves a paginated list of products belonging to a business.
- **Features**:
    - **Deduplication**: Ensures products linked to multiple branches of the same business appear only once using a custom JPQL `SELECT DISTINCT` query.
    - **Filtering**: Supports optional filtering by `categoryId`.
    - **Pagination**: Full support for `Pageable` (page, size, sort).

## Technical Details
- **Repository**: Added [findDistinctProductsByBusinessId](cci:1://file:///workspace/gestifysolution-server/src/main/java/com/ventuit/adminstrativeapp/products/repositories/ProductsRepository.java:16:4-27:31) query to [ProductsRepository](cci:2://file:///workspace/gestifysolution-server/src/main/java/com/ventuit/adminstrativeapp/products/repositories/ProductsRepository.java:10:0-28:1).
- **Service**: Updated [BusinessesService](cci:2://file:///workspace/gestifysolution-server/src/main/java/com/ventuit/adminstrativeapp/businesses/services/BusinessesService.java:33:0-225:1) to implement the retrieval logic and DTO mapping using `ProductsMapper`.
- **Controller**: Exposed the new endpoint in `BusinessesController`.